### PR TITLE
feat: dusk ceremony for bls12-381

### DIFF
--- a/setup/DuskBLS12_381/.gitignore
+++ b/setup/DuskBLS12_381/.gitignore
@@ -1,0 +1,2 @@
+response
+*.audit

--- a/setup/DuskBLS12_381/audit.go
+++ b/setup/DuskBLS12_381/audit.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+	"os"
+)
+
+const (
+	// The maximum number of tau powers computed in the Dusk Trusted Setup
+	FILE_MAX_TAU_POWERS = 1 << 21
+
+	// The size of G1 affine points in compressed form
+	G1_AFFINE_COMPRESSED_SIZE = 48
+
+	// The size of G2 affine points in compressed form
+	G2_AFFINE_COMPRESSED_SIZE = 96
+
+	// Hash size at the beginning of the response file
+	HASH_SIZE = 64
+)
+
+type Point struct {
+	Data []byte
+	Type string
+}
+
+func extractG1Points(responseBytes []byte) []Point {
+	var g1Points []Point
+	offset := HASH_SIZE // Skip the 64-byte hash at the beginning
+
+	// Extract powers of tau in G1 (τ^0, τ^1, τ^2, ..., τ^DUSK_MAX_TAU_POWERS)
+	for i := 0; i <= FILE_MAX_TAU_POWERS; i++ {
+		if offset+G1_AFFINE_COMPRESSED_SIZE > len(responseBytes) {
+			log.Printf("Warning: Not enough data for G1 point %d", i)
+			break
+		}
+
+		pointData := make([]byte, G1_AFFINE_COMPRESSED_SIZE)
+		copy(pointData, responseBytes[offset:offset+G1_AFFINE_COMPRESSED_SIZE])
+
+		g1Points = append(g1Points, Point{
+			Data: pointData,
+			Type: fmt.Sprintf("G1_tau_%d", i),
+		})
+
+		offset += G1_AFFINE_COMPRESSED_SIZE
+	}
+
+	return g1Points
+}
+
+func extractG2Points(responseBytes []byte) []Point {
+	var g2Points []Point
+
+	// Calculate offset for G2 generator
+	// G2 generator position: ((FILE_MAX_TAU_POWERS << 1) - 1) * G1_AFFINE_COMPRESSED_SIZE + 64
+	g2Offset := ((FILE_MAX_TAU_POWERS<<1)-1)*G1_AFFINE_COMPRESSED_SIZE + HASH_SIZE
+
+	// Extract G2 generator
+	if g2Offset+G2_AFFINE_COMPRESSED_SIZE <= len(responseBytes) {
+		g2Data := make([]byte, G2_AFFINE_COMPRESSED_SIZE)
+		copy(g2Data, responseBytes[g2Offset:g2Offset+G2_AFFINE_COMPRESSED_SIZE])
+
+		g2Points = append(g2Points, Point{
+			Data: g2Data,
+			Type: "G2_generator",
+		})
+	} else {
+		log.Println("Warning: Not enough data for G2 generator")
+	}
+
+	// Extract tau * G2 generator
+	tauG2Offset := g2Offset + G2_AFFINE_COMPRESSED_SIZE
+	if tauG2Offset+G2_AFFINE_COMPRESSED_SIZE <= len(responseBytes) {
+		tauG2Data := make([]byte, G2_AFFINE_COMPRESSED_SIZE)
+		copy(tauG2Data, responseBytes[tauG2Offset:tauG2Offset+G2_AFFINE_COMPRESSED_SIZE])
+
+		g2Points = append(g2Points, Point{
+			Data: tauG2Data,
+			Type: "G2_tau_generator",
+		})
+	} else {
+		log.Println("Warning: Not enough data for tau * G2 generator")
+	}
+
+	return g2Points
+}
+
+// run the audit
+func main() {
+	// Open the transcript.json file
+	_, err := os.Stat("response")
+	if err != nil {
+		log.Fatalf("Error checking existance of response: %v\n"+
+			"Refer to doc.go for instructions on how to download the file.", err)
+		return
+	}
+	file, err := os.Open("response")
+	if err != nil {
+		log.Fatal("Error opening response:", err)
+		return
+	}
+	defer file.Close()
+
+	responseBytes, err := os.ReadFile("response")
+	if err != nil {
+		log.Fatalf("error reading response file: %v", err)
+	}
+
+	g1Points := extractG1Points(responseBytes)
+
+	// Create the pk.audit file
+	file, err = os.Create("pk.audit")
+	if err != nil {
+		log.Fatalf("error creating pk.audit file: %v", err)
+	}
+	defer file.Close()
+
+	// Write the length of G1Powers as a 4-byte big-endian integer
+	length := uint32(len(g1Points))
+	err = binary.Write(file, binary.BigEndian, length)
+	if err != nil {
+		log.Fatalf("error writing length to file: %v", err)
+	}
+
+	// Convert and write each G1Power
+	for _, g1Power := range g1Points {
+		bytes := g1Power.Data
+
+		if err != nil {
+			log.Fatalf("error decoding hex string: %v", err)
+		}
+
+		// Ensure bytes slice is 48 bytes long
+		if len(bytes) != 48 {
+			log.Fatalf("decoded hex is not 48 bytes long")
+		}
+
+		// Write the 48-byte sequence to the file
+		_, err = file.Write(bytes)
+		if err != nil {
+			log.Fatalf("error writing G1Power to file: %v", err)
+		}
+	}
+
+	// Create the vk.audit file
+	file, err = os.Create("vk.audit")
+	if err != nil {
+		log.Fatalf("error creating vk.audit file: %v", err)
+	}
+	defer file.Close()
+
+	g2Points := extractG2Points(responseBytes)
+
+	// Convert and write the first two G2Powers
+	for _, g2Power := range g2Points {
+		bytes := g2Power.Data
+
+		// Ensure bytes slice is 96 bytes long
+		if len(bytes) != 96 {
+			log.Fatalf("decoded hex is not 96 bytes long")
+		}
+
+		// Write the 96-byte sequence to the file
+		_, err = file.Write(bytes)
+		if err != nil {
+			log.Fatalf("error writing G2Power to file: %v", err)
+		}
+	}
+	// Convert and write the first G1Power
+	bytes := g1Points[0].Data
+
+	_, err = file.Write(bytes)
+	if err != nil {
+		log.Fatalf("error writing G1Power to file: %v", err)
+	}
+
+	// check the files match
+	pk, err := os.ReadFile("pk.bin")
+	if err != nil {
+		log.Fatalf("error reading pk.bin: %v", err)
+	}
+	pkAudit, err := os.ReadFile("pk.audit")
+	if err != nil {
+		log.Fatalf("error reading pk.audit: %v", err)
+	}
+	if string(pk) != string(pkAudit) {
+		log.Fatalf("pk.bin and pk.audit files do not match")
+	}
+	vk, err := os.ReadFile("vk.bin")
+	if err != nil {
+		log.Fatalf("error reading vk.bin: %v", err)
+	}
+	vkAudit, err := os.ReadFile("vk.audit")
+	if err != nil {
+		log.Fatalf("error reading vk.audit: %v", err)
+	}
+	if string(vk) != string(vkAudit) {
+		log.Fatalf("vk.bin and vk.audit files do not match")
+	}
+	fmt.Println("Audit successful")
+}

--- a/setup/DuskBLS12_381/doc.go
+++ b/setup/DuskBLS12_381/doc.go
@@ -1,0 +1,20 @@
+/*
+package main contains the trusted parameters for the bls12_381 curve
+as described in the doc.go file in the setup package (parent folder).
+
+The parameters for the Prover and the Verifier are in the pk.bin and
+vk.bin files, respectively.
+
+These files have been created using the script in the audit.go file.
+To audit the parameters you need to:
+
+1) download the original response file from https://github.com/dusk-network/trusted-setup/tree/main/contributions/0015
+
+2) Place the `response` file in this directory
+
+3) Run the audit.go main program with `go run .`
+
+This will create the pk.audit and vs.audit files and test they match the
+pk.bin and vk.bin files.
+*/
+package main

--- a/setup/DuskBLS12_381/vk.bin
+++ b/setup/DuskBLS12_381/vk.bin
@@ -1,0 +1,3 @@
+“à+`RqŸ`}¬Ó ˆ'OeYkÐÐ™ ¶µÚa»ÜPI3Lñ”]Wå¬}]+~J¢²ð
+‘&'-ÅQÆäzÔú@;´QdzãÑw¬&¨»ïÔ€VÈÁ!½¸Ø@IæjÆE“ˆ©µba7÷‚`dŒæ¤¿]1„ŸÞ	&Dx+ö´. „"v«ç#ƒƒ´‹Ö%Z	3ïUUâÁ©û˜^!Î÷°V\;Tƒdcë=H—ñÓ§1—×”&•cŒO©¬ÃhŒO—t¹¡N:?¬XlUè?ùzïû:ð
+Û"Æ»

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -30,6 +30,7 @@ type Name int
 const (
 	PerpetualPowersOfTauBN254 Name = iota
 	EthereumKzgCeremonyBLS12381
+	DuskBLS12381
 	TestOnlyBN254
 	TestOnlyBLS12381
 )
@@ -57,6 +58,11 @@ var Setups = map[Name]Setup{
 		NamePath: "EethereumKzgCeremonyBLS12_381",
 		Trusted:  true,
 	},
+	DuskBLS12381: {
+		Curve:    ecc.BLS12_381,
+		NamePath: "DuskBLS12_381",
+		Trusted:  true,
+	},
 	TestOnlyBN254: {
 		Curve:    ecc.BN254,
 		NamePath: "test_only",
@@ -75,6 +81,8 @@ var Setups = map[Name]Setup{
 //go:embed EethereumKzgCeremonyBLS12_381/vk.bin
 //go:embed PerpetualPowersOfTauBN254/pk.bin
 //go:embed PerpetualPowersOfTauBN254/vk.bin
+//go:embed DuskBLS12_381/pk.bin
+//go:embed DuskBLS12_381/vk.bin
 var embeddedFiles embed.FS
 
 // Run sets up a plonk system using either a trusted or test only setup,

--- a/setup/setup_test.go
+++ b/setup/setup_test.go
@@ -29,6 +29,136 @@ func TestTrustedSetupPerpetualPowersOfTauBN254(t *testing.T) {
 	}
 }
 
+func TestTrustedSetupDuskBLS12381(t *testing.T) {
+	const size = 5
+	setup := Setups[DuskBLS12381]
+	srs, err := trustedSetupBLS12381(size, setup.NamePath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(srs.Pk.G1) != size {
+		t.Errorf("expected %d G1 elements, got %d", size, len(srs.Pk.G1))
+	}
+	checkG1 := [size]bls12381.G1Affine{}
+	checkG1Strings := [size]string{
+		"0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
+		"0xb00634601c69f919549b3a284249cee53e7be4cf96f05a8ceceec6c74a0a2bc5cb21a6b060bff4c11eb3382c0ca98325",
+		"0xb74090b6c7ad1daee5dcea5a70e0e0dd774b8308fe7e0084031ee84457de0d6f665cd55d81cbb5f650b66eccf6e4cd31",
+		"0x81704091e4770cdf58699eca0569d99d6d001b4191d380e8dd26feddcacafa9d2425f834fe61061af349fd18facc3744",
+		"0xb3f9536dba87c1b6bf29142b58f1760ebdbea7a5a5c92c2e2a221e903937d3da6098ebf1125cc1c8de82f234ad698001",
+	}
+
+	for i, g1 := range srs.Pk.G1 {
+		checkBytes, err := hex.DecodeString(checkG1Strings[i][2:])
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		err = checkG1[i].Unmarshal(checkBytes)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !g1.Equal(&checkG1[i]) {
+			g1Bytes := g1.Bytes()
+			g1Hex := hex.EncodeToString(g1Bytes[:])
+
+			t.Errorf("different g1: %s | %s for G1[%d]", g1Hex, checkG1Strings[i], i)
+		}
+		// Modify the first three bits to make it an uncompressed X
+		checkG1[i].X.SetString(zeroFirstThreeBits(checkG1Strings[i]))
+		if !g1.X.Equal(&checkG1[i].X) {
+			t.Errorf("different g1.X: %v | %v for G1[%d]", g1.X, checkG1[i].X, i)
+		}
+	}
+
+	// check srs.Pk.G1[0], srs.Vk.G2[0] are the G1, G2 bls12-381 generators
+	_, _, g1Gen, g2Gen := bls12381.Generators()
+	if !srs.Pk.G1[0].Equal(&g1Gen) {
+		t.Errorf("different g1 generator: %v | %v", srs.Pk.G1[0], g1Gen)
+	}
+	if !srs.Vk.G2[0].Equal(&g2Gen) {
+		t.Errorf("different g2 generator: %v | %v", srs.Vk.G2[0], g2Gen)
+	}
+
+	checkG2 := [2]bls12381.G2Affine{}
+	checkG2Strings := [2]string{
+		"0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
+		"0x8fd840491fe66a0cc60f45930d88a9b562136137f78260648ce6a4bf5d31849f18de090e2644780d2bf6b42e208422760fabe7238383b48bd61f25125a0d093306ef5511550312e2c1a9fb985e21ce1bf71b1fb0565c3b54836463eb1f043d48",
+	}
+	for i, g2 := range srs.Vk.G2 {
+		checkBytes, err := hex.DecodeString(checkG2Strings[i][2:])
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		err = checkG2[i].Unmarshal(checkBytes)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !g2.Equal(&checkG2[i]) {
+			g2Bytes := g2.Bytes()
+			g2Hex := hex.EncodeToString(g2Bytes[:])
+
+			t.Errorf("different g2: %s | %s for G2[%d]", g2Hex, checkG2Strings[i], i)
+		}
+		checkG2[i].X.SetString(checkG2Strings[i][2+96:],
+			zeroFirstThreeBits(checkG2Strings[i])[2:98])
+		if !g2.X.Equal(&checkG2[i].X) {
+			t.Errorf("different g2.X: %v | %v for G2[%d]", g2.X, checkG2[i].X, i)
+		}
+	}
+	if !srs.Vk.G1.Equal(&checkG1[0]) {
+		t.Errorf("different Vk.G1 %v | %v", srs.Vk.G1, checkG1[0])
+	}
+
+	const size2 = 32768
+	srs, err = trustedSetupBLS12381(size2, setup.NamePath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(srs.Pk.G1) != size2 {
+		t.Errorf("expected %d G1 elements, got %d", size2, len(srs.Pk.G1))
+	}
+
+	// let's check the last element
+	lastG1CheckString := "0x872d03410917bae2f3536a750ad10f7b7173d89fa27026afe5c0b2e08697eed244a6798ed833826198628058e3c8b0d9"
+	checkBytes, err := hex.DecodeString(lastG1CheckString[2:])
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	g1Check := bls12381.G1Affine{}
+	err = g1Check.Unmarshal(checkBytes)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	g1 := srs.Pk.G1[size2-1]
+	if !g1.Equal(&g1Check) {
+		g1Bytes := g1.Bytes()
+		g1Hex := hex.EncodeToString(g1Bytes[:])
+
+		g1CheckBytes := g1Check.Bytes()
+		g1CheckHex := hex.EncodeToString(g1CheckBytes[:])
+
+		t.Errorf("different g1: %v | %v for G1[%d]]", g1Hex, g1CheckHex, size2-1)
+	}
+
+	for i, g2 := range srs.Vk.G2 {
+		checkBytes, err := hex.DecodeString(checkG2Strings[i][2:])
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		err = checkG2[i].Unmarshal(checkBytes)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !g2.Equal(&checkG2[i]) {
+			t.Errorf("different g2: %v | %v for G2[%d]", g2, checkG1[i], i)
+		}
+	}
+	if !srs.Vk.G1.Equal(&checkG1[0]) {
+		t.Errorf("different Vk.G1 %v | %v", srs.Vk.G1, checkG1[0])
+
+	}
+}
+
 func TestTrustedSetupEethereumKzgCeremonyBLS12_381(t *testing.T) {
 	const size = 5
 	setup := Setups[EthereumKzgCeremonyBLS12381]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,7 +20,7 @@ import (
 // CompileWithPuyaPy compiles `filepath` with puyapy, with `options'.
 // Leave `options` empty to not pass any options
 func CompileWithPuyaPy(filepath string, options string) error {
-	args := []string{"compile", "py", filepath}
+	args := []string{"compile", "py", "-O0", filepath}
 	if options != "" {
 		args = append(args, options)
 	}


### PR DESCRIPTION
See https://github.com/dusk-network/trusted-setup for ceremony details and the rust code this was based on

Main reason for using the Dusk setup over ETH is the larger size. Marking as draft for now because we probably want to provide the option of using either ETH or Dusk setup. There's also the filecoin setup, which is even larger, but probably overkill for most uses: https://trusted-setup.filecoin.io/phase1/