### PR TITLE
fix: handle point-at-infinity edge case in `invert()`

### DIFF
--- a/verifier/templateLogicSigBLS12_381.go
+++ b/verifier/templateLogicSigBLS12_381.go
@@ -354,10 +354,12 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Invert a point on the curve."""
+	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
+	Uses modular reduction to correctly handle y=0 (point at infinity),
+	where P_MOD - 0 = P_MOD would produce an invalid field element."""
 	x = BigUInt.from_bytes(p[:48])
 	y = BigUInt.from_bytes(p[48:])
-	neg_y = BigUInt(P_MOD) - y
+	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
 	return x.bytes + (bzero(48) | (neg_y).bytes)
 
 @subroutine

--- a/verifier/templateLogicSigBLS12_381.go
+++ b/verifier/templateLogicSigBLS12_381.go
@@ -354,12 +354,12 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
-	Uses modular reduction to correctly handle y=0 (point at infinity),
-	where P_MOD - 0 = P_MOD would produce an invalid field element."""
+	"""Invert a point on the curve."""
 	x = BigUInt.from_bytes(p[:48])
 	y = BigUInt.from_bytes(p[48:])
-	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
+	if y == BigUInt(0):
+		return p
+	neg_y = BigUInt(P_MOD) - y
 	return x.bytes + (bzero(48) | (neg_y).bytes)
 
 @subroutine

--- a/verifier/templateLogicSigBN254.go
+++ b/verifier/templateLogicSigBN254.go
@@ -342,9 +342,11 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Invert a point on the curve."""
+	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
+	Uses modular reduction to correctly handle y=0 (point at infinity),
+	where P_MOD - 0 = P_MOD would produce an invalid field element."""
 	x = BigUInt.from_bytes(p[:32])
 	y = BigUInt.from_bytes(p[32:])
-	neg_y = BigUInt(P_MOD) - y
+	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
 	return x.bytes + UInt256(neg_y).bytes
 `

--- a/verifier/templateLogicSigBN254.go
+++ b/verifier/templateLogicSigBN254.go
@@ -342,11 +342,11 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
-	Uses modular reduction to correctly handle y=0 (point at infinity),
-	where P_MOD - 0 = P_MOD would produce an invalid field element."""
+	"""Invert a point on the curve."""
 	x = BigUInt.from_bytes(p[:32])
 	y = BigUInt.from_bytes(p[32:])
-	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
+	if y == BigUInt(0):
+		return p
+	neg_y = BigUInt(P_MOD) - y
 	return x.bytes + UInt256(neg_y).bytes
 `

--- a/verifier/templateSmartContractBLS12_381.go
+++ b/verifier/templateSmartContractBLS12_381.go
@@ -381,10 +381,12 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Invert a point on the curve."""
+	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
+	Uses modular reduction to correctly handle y=0 (point at infinity),
+	where P_MOD - 0 = P_MOD would produce an invalid field element."""
 	x = BigUInt.from_bytes(p[:48])
 	y = BigUInt.from_bytes(p[48:])
-	neg_y = BigUInt(P_MOD) - y
+	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
 	return x.bytes + (bzero(48) | (neg_y).bytes)
 
 @subroutine

--- a/verifier/templateSmartContractBLS12_381.go
+++ b/verifier/templateSmartContractBLS12_381.go
@@ -381,12 +381,12 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
-	Uses modular reduction to correctly handle y=0 (point at infinity),
-	where P_MOD - 0 = P_MOD would produce an invalid field element."""
+	"""Invert a point on the curve."""
 	x = BigUInt.from_bytes(p[:48])
 	y = BigUInt.from_bytes(p[48:])
-	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
+	if y == BigUInt(0):
+		return p
+	neg_y = BigUInt(P_MOD) - y
 	return x.bytes + (bzero(48) | (neg_y).bytes)
 
 @subroutine

--- a/verifier/templateSmartContractBN254.go
+++ b/verifier/templateSmartContractBN254.go
@@ -363,9 +363,11 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Invert a point on the curve."""
+	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
+	Uses modular reduction to correctly handle y=0 (point at infinity),
+	where P_MOD - 0 = P_MOD would produce an invalid field element."""
 	x = BigUInt.from_bytes(p[:32])
 	y = BigUInt.from_bytes(p[32:])
-	neg_y = BigUInt(P_MOD) - y
+	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
 	return x.bytes + UInt256(neg_y).bytes
 `

--- a/verifier/templateSmartContractBN254.go
+++ b/verifier/templateSmartContractBN254.go
@@ -363,11 +363,11 @@ def curvemod(x: Bytes) -> BigUInt:
 
 @subroutine
 def invert(p : Bytes) -> Bytes:
-	"""Negate a point on the curve by negating the y-coordinate modulo P_MOD.
-	Uses modular reduction to correctly handle y=0 (point at infinity),
-	where P_MOD - 0 = P_MOD would produce an invalid field element."""
+	"""Invert a point on the curve."""
 	x = BigUInt.from_bytes(p[:32])
 	y = BigUInt.from_bytes(p[32:])
-	neg_y = (BigUInt(P_MOD) - y) % BigUInt(P_MOD)
+	if y == BigUInt(0):
+		return p
+	neg_y = BigUInt(P_MOD) - y
 	return x.bytes + UInt256(neg_y).bytes
 `


### PR DESCRIPTION
Closes #4

## Problem

The `invert()` subroutine computes `neg_y = P_MOD - y` to negate a curve point. When `y = 0` (point at infinity), this produces `neg_y = P_MOD`, which is not a valid field element, field elements must be in `[0, P_MOD)`. This corrupts downstream Fiat-Shamir transcript hashing and EC opcode inputs.

## Fix

Apply modular reduction: `neg_y = (P_MOD - y) % P_MOD`

- `y = 0` → `(P_MOD - 0) % P_MOD = 0` (correct)
- `y > 0` → `(P_MOD - y) % P_MOD = P_MOD - y` (unchanged behavior)

## Files changed

- `verifier/templateLogicSigBN254.go`
- `verifier/templateSmartContractBN254.go`
- `verifier/templateLogicSigBLS12_381.go`
- `verifier/templateSmartContractBLS12_381.go`