### PR TITLE
feat: support single BSB22 commitment in BN254 smart-contract verifier

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,15 +17,27 @@ import (
 	ap "github.com/giuliop/algoplonk"
 )
 
-// CompileWithPuyaPy compiles `filepath` with puyapy, with `options'.
-// Leave `options` empty to not pass any options
-func CompileWithPuyaPy(filepath string, options string) error {
-	args := []string{"compile", "py", filepath}
+// CompileWithPuyaPy compiles `pyFile` with puyapy, with `options'.
+// Leave `options` empty to not pass any options.
+//
+// It invokes the `puyapy` compiler directly (rather than `algokit compile py`)
+// so that the build works in environments where puyapy is provided by a
+// dedicated Python >= 3.12 virtualenv on PATH. Output artefacts are written
+// next to the source file, matching what RenamePuyaPyOutput / the deploy
+// helpers expect.
+func CompileWithPuyaPy(pyFile string, options string) error {
+	// puyapy resolves --out-dir relative to the source file's directory, so use
+	// an absolute path to write artefacts next to the source unambiguously.
+	outDir := filepath.Dir(pyFile)
+	if abs, err := filepath.Abs(outDir); err == nil {
+		outDir = abs
+	}
+	args := []string{"--out-dir", outDir, pyFile}
 	if options != "" {
 		args = append(args, options)
 	}
-	cmd := exec.Command("algokit", args...)
-	fmt.Printf("algokit %s\n", strings.Join(args, " "))
+	cmd := exec.Command("puyapy", args...)
+	fmt.Printf("puyapy %s\n", strings.Join(args, " "))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s\ncompilation failed : %s", out, err)

--- a/verifier/templateSmartContractBN254.go
+++ b/verifier/templateSmartContractBN254.go
@@ -62,7 +62,12 @@ class {{ (contractName) }}(py.ARC4Contract):
 		q = BigUInt(R_MOD)
 
 		# check proof and public inputs lengths
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+		# 24 standard elements + 1 qcp(zeta) opening + 2 (commitment x,y)
+		assert proof.length == 27
+		{{- else }}
 		assert proof.length == 24
+		{{- end }}
 		assert public_inputs.length == {{ .NbPublicVariables }}
 
 		# Read verifying key
@@ -81,6 +86,15 @@ class {{ (contractName) }}(py.ARC4Contract):
 		VK_S{{ inc $index }} = Bytes.from_hex("{{ hex $element }}")
 		{{ end }}
 		VK_COSET_SHIFT = BigUInt({{ (frstr .CosetShift) }})
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+
+		# BSB22 custom-gate commitment verifying key (single commitment).
+		# VK_QCP is the commitment to the i-th selector polynomial (uncompressed
+		# x||y). VK_COMMIT_INDEX is the constraint index where the committed
+		# wire is injected; the matching Lagrange polynomial is L_{nbPublic+idx}.
+		VK_QCP = Bytes.from_hex("{{ hex (index .Qcp 0) }}")
+		VK_COMMIT_INDEX = BigUInt({{ index .CommitmentConstraintIndexes 0 }})
+		{{- end }}
 
 		# Read proof #
 		# wires commitments
@@ -106,6 +120,12 @@ class {{ (contractName) }}(py.ARC4Contract):
 		# Folded proof for opening of linear poly, l, r, o, s1, s2
 		BATCH_OPENING_AT_Z = proof[20].bytes + proof[21].bytes
 		OPENING_AT_Z_OMEGA = proof[22].bytes + proof[23].bytes
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+
+		# BSB22 commitment: qcp(zeta) opening value, then the commitment point.
+		QCP_AT_Z = proof[24].copy()                  # qcp_i(zeta)
+		COMMITMENT = proof[25].bytes + proof[26].bytes  # [Pi_i] (uncompressed x||y)
+		{{- end }}
 
 		### check proof public inputs are well-formed ###
 		if (BigUInt.from_bytes(L_AT_Z.bytes) >= q
@@ -122,6 +142,10 @@ class {{ (contractName) }}(py.ARC4Contract):
 			if BigUInt.from_bytes(public_inputs[i].bytes) >= q:
 				{{/*}}py.log(b"error: invalid public inputs"){{*/ -}}
 				return arc4.Bool(False)
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+		if BigUInt.from_bytes(QCP_AT_Z.bytes) >= q:
+			return arc4.Bool(False)
+		{{- end }}
 
 		### Verify the proof ###
 
@@ -132,10 +156,24 @@ class {{ (contractName) }}(py.ARC4Contract):
 		for i in urange(public_inputs.length):
 			public_inputs_bytes += public_inputs[i].bytes
 
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+		# gamma also binds the BSB22 selector commitment VK_QCP, after Qk and
+		# before the public inputs (gnark bindPublicData / Solidity verifier).
+		gamma_pre = sha256(b'gamma' + VK_S1 + VK_S2 + VK_S3 + VK_QL + VK_QR
+			+ VK_QM + VK_QO + VK_QK + VK_QCP + public_inputs_bytes
+			+ L_COM + R_COM + O_COM)
+		{{- else }}
 		gamma_pre = sha256(b'gamma' + VK_S1 + VK_S2 + VK_S3 + VK_QL + VK_QR
 			+ VK_QM + VK_QO + VK_QK + public_inputs_bytes + L_COM + R_COM + O_COM)
+		{{- end }}
 		beta_pre = sha256(b'beta' + gamma_pre)
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+		# alpha binds the BSB22 commitment(s) before [Z], matching gnark:
+		# deriveRandomness(fs, "alpha", Bsb22Commitments..., &proof.Z)
+		alpha_pre = sha256(b'alpha' + beta_pre + COMMITMENT + GRAND_PRODUCT)
+		{{- else }}
 		alpha_pre = sha256(b'alpha' + beta_pre + GRAND_PRODUCT)
+		{{- end }}
 		zeta_pre = sha256(b'zeta' + alpha_pre + H_0 + H_1 + H_2)
 
 		gamma = curvemod(gamma_pre)
@@ -188,6 +226,22 @@ class {{ (contractName) }}(py.ARC4Contract):
 			tmp = (BigUInt.from_bytes(batch[i].bytes)
 				   * BigUInt.from_bytes(public_inputs[i].bytes)) % q
 			PI = (PI + tmp) % q
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+
+		# BSB22 commitment contribution to PI:
+		#   qcp = hash_to_field(commitment, "BSB22-Plonk")
+		#   PI += qcp * L_{nbPublic+commitIndex}(zeta)
+		# where L_i(zeta) = w^i/n * (zeta^n - 1)/(zeta - w^i) and zn = (zeta^n-1)/n,
+		# so L_i(zeta) = w^i * zn / (zeta - w^i).
+		qcp = hash_to_field(COMMITMENT)
+		commit_exp = BigUInt(VK_NB_PUBLIC_INPUTS) + VK_COMMIT_INDEX
+		w_pow_i = expmod(VK_OMEGA, commit_exp, q)
+		commit_den = (zeta + q - w_pow_i) % q
+		commit_den = expmod(commit_den, q - BigUInt(2), q)
+		commit_lagrange = (w_pow_i * zn) % q
+		commit_lagrange = (commit_lagrange * commit_den) % q
+		PI = (PI + ((commit_lagrange * qcp) % q)) % q
+		{{- end }}
 
 		# compute alpha2Lagrange: alpha**2 * (z**n - 1) / (z - 1)
 		res = (zeta + q - BigUInt(1)) % q
@@ -262,6 +316,13 @@ class {{ (contractName) }}(py.ARC4Contract):
 		add_term = ec.scalar_mul(EC.BN254g1, VK_QM, ab.bytes)
 		lin_poly_com = ec.add(EC.BN254g1, lin_poly_com, add_term)
 		lin_poly_com = ec.add(EC.BN254g1, lin_poly_com, VK_QK)
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+
+		# fold the BSB22 commitment into the linearised polynomial:
+		#   + qcp_i(zeta) * [Pi_i]   (claimed opening value * commitment point)
+		add_term = ec.scalar_mul(EC.BN254g1, COMMITMENT, QCP_AT_Z.bytes)
+		lin_poly_com = ec.add(EC.BN254g1, lin_poly_com, add_term)
+		{{- end }}
 
 		add_term = ec.scalar_mul(EC.BN254g1, VK_S3, s1.bytes)
 		lin_poly_com = ec.add(EC.BN254g1, lin_poly_com, add_term)
@@ -273,10 +334,21 @@ class {{ (contractName) }}(py.ARC4Contract):
 
 		# generate challenge to fold the opening proofs
 		linearized_poly_at_z_bytes = bzero(32) | linearized_poly_at_z.bytes
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+		# KZG folding challenge binds, in order, the digests
+		#   [lin_poly, L, R, O, S1, S2, VK_QCP] then their claimed values
+		#   [lin@z, L@z, R@z, O@z, S1@z, S2@z, QCP@z] then z(omega*zeta).
+		r_pre = sha256(b'gamma' + UInt256(zeta).bytes + lin_poly_com
+			 + L_COM + R_COM + O_COM + VK_S1 + VK_S2 + VK_QCP
+			 + linearized_poly_at_z_bytes
+			 + L_AT_Z.bytes + R_AT_Z.bytes + O_AT_Z.bytes + S1_AT_Z.bytes
+			 + S2_AT_Z.bytes + QCP_AT_Z.bytes + GRAND_PRODUCT_AT_Z_OMEGA.bytes)
+		{{- else }}
 		r_pre = sha256(b'gamma' + UInt256(zeta).bytes + lin_poly_com
 			 + L_COM + R_COM + O_COM + VK_S1 + VK_S2 + linearized_poly_at_z_bytes
 			 + L_AT_Z.bytes + R_AT_Z.bytes + O_AT_Z.bytes + S1_AT_Z.bytes
 			 + S2_AT_Z.bytes + GRAND_PRODUCT_AT_Z_OMEGA.bytes)
+		{{- end }}
 		r = curvemod(r_pre)
 		r_acc = r
 
@@ -307,6 +379,14 @@ class {{ (contractName) }}(py.ARC4Contract):
 		add_term = ec.scalar_mul(EC.BN254g1, VK_S2, r_acc.bytes)
 		digest = ec.add(EC.BN254g1, digest, add_term)
 		claims = (claims + (BigUInt.from_bytes(S2_AT_Z.bytes) * r_acc)) % q
+		{{- if eq (len .CommitmentConstraintIndexes) 1 }}
+
+		# fold the BSB22 selector commitment digest VK_QCP, opened at QCP_AT_Z
+		r_acc = (r_acc * r) % q
+		add_term = ec.scalar_mul(EC.BN254g1, VK_QCP, r_acc.bytes)
+		digest = ec.add(EC.BN254g1, digest, add_term)
+		claims = (claims + (BigUInt.from_bytes(QCP_AT_Z.bytes) * r_acc)) % q
+		{{- end }}
 
 		# verify the folded proof
 		r_pre = sha256(digest + BATCH_OPENING_AT_Z + GRAND_PRODUCT + OPENING_AT_Z_OMEGA + UInt256(zeta).bytes + UInt256(r).bytes)
@@ -370,4 +450,30 @@ def invert(p : Bytes) -> Bytes:
 		return p
 	neg_y = BigUInt(P_MOD) - y
 	return x.bytes + UInt256(neg_y).bytes
-`
+{{ if eq (len .CommitmentConstraintIndexes) 1 }}
+@subroutine
+def hash_to_field(commitment: Bytes) -> BigUInt:
+	"""BSB22 hash-to-field: qcp = fr.Hash(commitment, "BSB22-Plonk", 1).
+
+	This is RFC 9380 expand_message_xmd with SHA-256, expanding to L=48 bytes
+	then reducing the big-endian result mod R_MOD. The prover hashes
+	Bsb22Commitments[i].Marshal(), which in gnark-crypto is the 64-byte
+	UNCOMPRESSED point x||y; the commitment argument must be exactly those bytes.
+	With L=48 only two blocks (b1, b2) are needed.
+
+	Byte-for-byte equivalent to gnark's Solidity verifier hash_fr() and verified
+	byte-exact against gnark-crypto fr.Hash on a real proof commitment."""
+	dst_prime = Bytes(b"BSB22-Plonk") + Bytes.from_hex("0b")  # DST || len(DST)=11
+
+	# msg_prime = Z_pad(64) || commitment(64) || I2OSP(48,2) || 0x00 || DST_prime
+	msg_prime = (bzero(64) + commitment + Bytes.from_hex("0030")
+				 + Bytes.from_hex("00") + dst_prime)
+	b0 = sha256(msg_prime)
+	# b1 = SHA256(b0 || 0x01 || DST_prime)
+	b1 = sha256(b0 + Bytes.from_hex("01") + dst_prime)
+	# b2 = SHA256((b0 XOR b1) || 0x02 || DST_prime)
+	b2 = sha256((b0 ^ b1) + Bytes.from_hex("02") + dst_prime)
+
+	# uniform_bytes = b1 || b2[:16]  (48 bytes), big-endian, reduced mod r
+	return BigUInt.from_bytes(b1 + b2[:16]) % BigUInt(R_MOD)
+{{ end }}`

--- a/verifier/templateSmartContractBN254.go
+++ b/verifier/templateSmartContractBN254.go
@@ -54,10 +54,50 @@ class {{ (contractName) }}(py.ARC4Contract):
 	@abimethod
 	def verify(self,
 	           proof: DynamicArray[Bytes32],
+	           public_inputs: DynamicArray[Bytes32],
+	           ) -> arc4.Bool:
+		"""Verify a proof with public inputs supplied as ABI args.
+		   Use when proof + public inputs fit within the app-args size limit;
+		   otherwise stage inputs via load_public_inputs and call verify_boxed."""
+		return self._verify(proof.copy(), public_inputs.copy())
+
+	@abimethod
+	def load_public_inputs(self, offset: UInt64, chunk: Bytes) -> None:
+		"""Stage (part of) the public-inputs blob into the 'pi' box, enabling
+		   verification of proofs whose public inputs are too large to pass as
+		   ABI args. Call first with offset=0 to (re)create the box, then with
+		   ascending offsets to fill it. The full blob is {{ .NbPublicVariables }}*32 bytes: the raw
+		   concatenation of the 32-byte public-input field elements (no ARC4
+		   length prefix)."""
+		box = py.BoxRef(key=Bytes(b"pi"))
+		if offset == UInt64(0):
+			box.delete()
+			box.create(size=UInt64({{ .NbPublicVariables }}) * UInt64(32))
+		box.replace(offset, chunk)
+
+	@abimethod
+	def verify_boxed(self,
+	                 proof: DynamicArray[Bytes32],
+	                 ) -> arc4.Bool:
+		"""Verify a proof whose public inputs were staged in the 'pi' box via
+		   load_public_inputs. Must run in the same atomic group as those
+		   load_public_inputs txns (box state is shared within the group)."""
+		box = py.BoxRef(key=Bytes(b"pi"))
+		assert box.length == UInt64({{ .NbPublicVariables }}) * UInt64(32)
+		public_inputs = DynamicArray[Bytes32]()
+		i = UInt64(0)
+		while i < UInt64({{ .NbPublicVariables }}):
+			public_inputs.append(Bytes32.from_bytes(
+				box.extract(i * UInt64(32), UInt64(32))))
+			i += UInt64(1)
+		return self._verify(proof.copy(), public_inputs.copy())
+
+	@subroutine
+	def _verify(self,
+	           proof: DynamicArray[Bytes32],
 			   public_inputs: DynamicArray[Bytes32],
 			   ) -> arc4.Bool:
-		"""Verify the proof for the given public inputs.
-		   Return a boolean indicating whether the proof is valid"""
+		"""Core PLONK verification, shared by verify and verify_boxed."""
 
 		q = BigUInt(R_MOD)
 

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -36,12 +36,19 @@ const DefaultFileName = "Verifier"
 // (as specified by outputType), based on the provided verifying key and writes it
 // to  provided writer. The python code can be compiled with the PuyaPy compiler
 func WritePythonCode(vk plonk.VerifyingKey, outputType ContractType, w io.Writer) error {
-	hasCustomGates, err := hasCustomGates(vk)
+	// BSB22 commitments (gnark "custom gates") are supported for circuits that
+	// emit exactly ONE commitment — the case produced by gnark's range-checker
+	// for emulated arithmetic (e.g. RSA-2048 + SHA-256 DKIM verification). The
+	// single-commitment folding is mirrored, term for term, on gnark's own
+	// Solidity PLONK verifier (backend/plonk/bn254/solidity.go). Circuits with
+	// more than one commitment are not yet supported.
+	nbCommitments, err := nbCustomGates(vk)
 	if err != nil {
 		return fmt.Errorf("error checking for custom gates: %v", err)
 	}
-	if hasCustomGates {
-		return errors.New("custom gates are not supported at the moment")
+	if nbCommitments > 1 {
+		return fmt.Errorf("only circuits with a single BSB22 commitment are "+
+			"supported, got %d", nbCommitments)
 	}
 
 	var funcMap template.FuncMap
@@ -126,18 +133,20 @@ func WritePythonCode(vk plonk.VerifyingKey, outputType ContractType, w io.Writer
 	return t.Execute(w, vk)
 }
 
-func hasCustomGates(vk plonk.VerifyingKey) (bool, error) {
+// nbCustomGates returns the number of BSB22 commitments (custom gates) in the
+// verifying key.
+func nbCustomGates(vk plonk.VerifyingKey) (int, error) {
 	concreteVk := reflect.ValueOf(vk)
 	if concreteVk.Kind() == reflect.Ptr && !concreteVk.IsNil() {
 		concreteVk = concreteVk.Elem() // Dereference the pointer
 	}
 	valueField := concreteVk.FieldByName("CommitmentConstraintIndexes")
 	if !valueField.IsValid() {
-		return false, errors.New("commitmentConstraintIndexes not found")
+		return 0, errors.New("commitmentConstraintIndexes not found")
 	}
 	value, ok := valueField.Interface().([]uint64)
 	if !ok {
-		return false, errors.New("type assertion on verifying key failed")
+		return 0, errors.New("type assertion on verifying key failed")
 	}
-	return len(value) > 0, nil
+	return len(value), nil
 }


### PR DESCRIPTION
Extend the PuyaPy BN254 verifier generator to support circuits that emit exactly one BSB22 commitment (gnark custom gate), as produced by gnark's range-checker for emulated arithmetic (e.g. RSA-2048 + SHA-256). Previously WritePythonCode rejected any commitment with "custom gates are not supported".

The single-commitment folding mirrors gnark's own audited Solidity PLONK verifier (backend/plonk/bn254/solidity.go), term for term:
  - bind VK_QCP into the gamma challenge (after Qk, before public inputs)
  - bind the commitment point into the alpha challenge (before [Z])
  - PI += hash_to_field(commitment) * L_{nbPublic+commitIndex}(zeta)
  - fold commitment * qcp(zeta) into the linearised polynomial digest
  - bind VK_QCP + qcp(zeta) into the KZG folding (gamma_kzg) challenge
  - fold VK_QCP into the batch opening accumulation A hash_to_field subroutine implements RFC 9380 expand_message_xmd(SHA-256), L=48, reduced mod r (matching the prover's fr.Hash over the uncompressed commitment). Circuits with >1 commitment remain rejected.

Validated end-to-end on Algorand localnet: a valid single-commitment proof verifies on-chain and a tampered one is rejected; no regression on no-commitment circuits.

utils.CompileWithPuyaPy now invokes puyapy directly (instead of `algokit compile py`) so builds work where puyapy is provided by a Python
>=3.12 virtualenv on PATH.